### PR TITLE
Fix double space bug

### DIFF
--- a/src/core/cutScene.ts
+++ b/src/core/cutScene.ts
@@ -7,10 +7,9 @@ export interface iSceneNode {
     nextScene: string;
 }
 
-export class BeforeLevelScene extends ex.Scene {
+export class CutScene extends ex.Scene {
 
     protected text: string[] = [];
-    public bubbleEnded: boolean = false;
 
     onInitialize(engine: ex.Engine) {
         const actor = new ex.Actor({ x: 250, y: 500, anchor: ex.vec(0.5, 1) });
@@ -22,14 +21,7 @@ export class BeforeLevelScene extends ex.Scene {
             { x: 10, y: engine.drawHeight - 80, right: engine.drawWidth - 20, down: 80 },
             this.text
         );
-        bubble.on(`sequence-${bubble.id}`, () => { this.bubbleEnded = true; });
+        bubble.on(`sequence-${bubble.id}`, () => { stats.nextScene = true; });
         engine.add(bubble);
-    }
-    onPreUpdate(engine: ex.Engine, delta: number) {
-        if (this.bubbleEnded) {
-            if (engine.input.keyboard.wasPressed(ex.Input.Keys.Space) || engine.input.keyboard.wasPressed(ex.Input.Keys.Right)) {
-                stats.nextScene = true;
-            }
-        }
     }
 }

--- a/src/core/levelLayout.ts
+++ b/src/core/levelLayout.ts
@@ -1,7 +1,7 @@
 import * as ex from 'excalibur';
 import { Player } from '../actors/player';
 import { stats } from './stats';
-import { iSceneNode } from './storyScene';
+import { iSceneNode } from './cutScene';
 import { iLocation } from './location';
 
 export class LevelLayout extends ex.Scene implements iSceneNode {

--- a/src/core/textBubble.ts
+++ b/src/core/textBubble.ts
@@ -99,7 +99,6 @@ export class TextBubble extends ex.ScreenElement {
         this.timer.stop();
     }
     bubbleEnded() {
-        //this.kill();
         this.emit(`sequence-${this.id}`);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { stats } from './core/stats';
 import { PlayerSelect } from './scenes/playerSelect';
 import { Level1 } from './scenes/level1';
 import { BeforeLevel1, BeforeLevel2 } from './scenes/beforeScenes';
-import { iSceneNode } from './core/storyScene';
+import { iSceneNode } from './core/cutScene';
 import { Level2 } from './scenes/level2';
 
 const engine = new ex.Engine({

--- a/src/scenes/beforeScenes.ts
+++ b/src/scenes/beforeScenes.ts
@@ -1,6 +1,6 @@
-import { BeforeLevelScene, iSceneNode } from '../core/storyScene';
+import { CutScene, iSceneNode } from '../core/cutScene';
 
-export class BeforeLevel1 extends BeforeLevelScene implements iSceneNode {
+export class BeforeLevel1 extends CutScene implements iSceneNode {
 
     nextScene = "level1";
     thisScene = "beforeLevel1";
@@ -14,7 +14,7 @@ export class BeforeLevel1 extends BeforeLevelScene implements iSceneNode {
     ]
 }
 
-export class BeforeLevel2 extends BeforeLevelScene {
+export class BeforeLevel2 extends CutScene {
     nextScene = "level2";
     thisScene = "beforeLevel2";
 

--- a/src/scenes/example.ts
+++ b/src/scenes/example.ts
@@ -4,7 +4,7 @@ import { Floor, Ground, Wall } from '../actors/ground';
 import { NPC } from '../actors/npc';
 import { Gate } from '../actors/gate';
 import { LevelLayout } from '../core/levelLayout';
-import { iSceneNode } from '../core/storyScene';
+import { iSceneNode } from '../core/cutScene';
 import { Potion } from '../actors/potion';
 import { tileSize } from '../core/resources';
 import { Lift } from '../actors/lift';

--- a/src/scenes/gameover.ts
+++ b/src/scenes/gameover.ts
@@ -1,5 +1,5 @@
 import * as ex from 'excalibur';
-import { iSceneNode } from '../core/storyScene';
+import { iSceneNode } from '../core/cutScene';
 import { stats } from '../core/stats';
 
 export class GameOver extends ex.Scene implements iSceneNode {

--- a/src/scenes/level1.ts
+++ b/src/scenes/level1.ts
@@ -2,7 +2,7 @@ import * as ex from 'excalibur';
 import { LevelLayout } from '../core/levelLayout';
 import { Floor, Wall } from '../actors/ground';
 import { Gate } from '../actors/gate';
-import { iSceneNode } from '../core/storyScene';
+import { iSceneNode } from '../core/cutScene';
 
 export class Level1 extends LevelLayout implements iSceneNode {
     thisScene = "level1";

--- a/src/scenes/level2.ts
+++ b/src/scenes/level2.ts
@@ -2,7 +2,7 @@ import * as ex from 'excalibur';
 import { LevelLayout } from '../core/levelLayout';
 import { Floor, Wall } from '../actors/ground';
 import { Gate } from '../actors/gate';
-import { iSceneNode } from '../core/storyScene';
+import { iSceneNode } from '../core/cutScene';
 
 export class Level2 extends LevelLayout implements iSceneNode {
     thisScene = "level2";

--- a/src/scenes/playerSelect.ts
+++ b/src/scenes/playerSelect.ts
@@ -3,7 +3,7 @@ import { boy, girl } from '../core/resources';
 import { stats } from '../core/stats';
 import { iCharacter } from '../core/icharacter';
 import { TextBubble } from '../core/textBubble';
-import { iSceneNode } from '../core/storyScene';
+import { iSceneNode } from '../core/cutScene';
 
 
 class SelectorButton extends ex.ScreenElement {


### PR DESCRIPTION
This fixes: Cut scene end requires hitting space twice #11 Also renamed BeforeLevelScene to CutScene

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/WimYedema/alan-and-ada/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #11 

## Changes:

- Bug fixed
- BeforeLevelScene renamed to CutScene
