### PR TITLE
Detect (un)hide outside excalibur

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,10 +49,6 @@ engine.goToScene(stats.currentNode);
 let showDebug = false;
 
 // Game events to handle
-engine.on('hidden', () => {
-    console.log('pause');
-    engine.stop();
-});
 engine.on('preupdate', () => {
     if (engine.input.keyboard.wasPressed(ex.Input.Keys.Escape)) {
         showDebug = !showDebug;
@@ -69,9 +65,16 @@ engine.on('preupdate', () => {
         engine.goToScene('gameover');
     }
 })
-engine.on('visible', () => {
-    console.log('start');
-    engine.start();
+// Detect hidden and visible outside of excalibur: it blocks events when the
+// engine is stopped so we cannot detect when to resume.
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+        console.log('Window hidden');
+        engine.stop();
+    } else if (document.visibilityState === 'visible') {
+        console.log('Window visible');
+        engine.start();
+    }
 });
 
 // Start the engine


### PR DESCRIPTION
Excalibur stops the entire event loop when the engine stops so the "visible" event never arrives.

===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/WimYedema/alan-and-ada/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #9

## Changes:

- Pause and resume engine based on low-level visibilitychange event on document
