### PR TITLE
Change level order and reload to same level

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ The following key combo's can be used to help development:
 | ---------- | -------------------------------------------------- |
 | **Escape** | Enter debug-mode: visualize bounding boxes and ids |
 | **N**      | Only in debug-mode: finish the current level       |
+| **R**      | Only in debug-mode: restart the game               |
 
 # Credits
 

--- a/src/core/stats.ts
+++ b/src/core/stats.ts
@@ -6,6 +6,15 @@ export class Stats {
   public nextScene: boolean = false;
   public currentNode: string = "playerSelect";
   public score: number = 0;
+  load(d: any) {
+    this.charName = d["charName"];
+    this.health = d["health"];
+    this.assignment = d["assignment"];
+    this.gameOver = d["gameOver"];
+    this.nextScene = d["nextScene"];
+    this.currentNode = d["currentNode"];
+    this.score = d["score"];
+  }
   public reset() {
     this.health = 100;
     this.gameOver = false;

--- a/src/core/stats.ts
+++ b/src/core/stats.ts
@@ -7,13 +7,13 @@ export class Stats {
   public currentNode: string = "playerSelect";
   public score: number = 0;
   load(d: any) {
-    this.charName = d["charName"];
-    this.health = d["health"];
-    this.assignment = d["assignment"];
-    this.gameOver = d["gameOver"];
-    this.nextScene = d["nextScene"];
-    this.currentNode = d["currentNode"];
-    this.score = d["score"];
+    this.charName = d["charName"] ?? this.charName;
+    this.health = d["health"] ?? this.health;
+    this.assignment = d["assignment"] ?? this.assignment;
+    this.gameOver = d["gameOver"] ?? this.gameOver;
+    this.nextScene = d["nextScene"] ?? this.nextScene;
+    this.currentNode = d["currentNode"] ?? this.currentNode;
+    this.score = d["score"] ?? this.score;
   }
   public reset() {
     this.health = 100;

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,9 @@ addNode(new Level3());
 addNode(new Finish());
 addNode(new GameOver());
 
-stats.currentNode = "playerSelect";
+const st = JSON.parse(window.localStorage.getItem("stats")||"{}");
+console.log(st);
+stats.load(st);
 engine.goToScene(stats.currentNode);
 let showDebug = false;
 
@@ -62,18 +64,23 @@ engine.on("preupdate", () => {
   if (engine.input.keyboard.wasPressed(ex.Input.Keys.Escape)) {
     showDebug = !showDebug;
     engine.showDebug(showDebug);
-  } else if (
-    showDebug &&
-    engine.input.keyboard.wasPressed(ex.Input.Keys.KeyN)
-  ) {
-    stats.nextScene = true;
+  } else if (showDebug) {
+    if(engine.input.keyboard.wasPressed(ex.Input.Keys.KeyN)) {
+      stats.nextScene = true;
+    } else if(engine.input.keyboard.wasPressed(ex.Input.Keys.KeyR)) {
+      stats.currentNode = "playerSelect";
+      engine.goToScene(nodes[stats.currentNode].thisScene);
+      window.localStorage.setItem("stats", JSON.stringify(stats));
+    }
   }
+    
   if (stats.nextScene) {
     console.log("switching from ", stats.currentNode);
     stats.currentNode = nodes[stats.currentNode].nextScene;
     stats.nextScene = false;
     console.log("switching to ", stats.currentNode);
     engine.goToScene(nodes[stats.currentNode].thisScene);
+    window.localStorage.setItem("stats", JSON.stringify(stats));
   } else if (stats.gameOver) {
     stats.currentNode = "gameover";
     engine.goToScene("gameover");

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,6 @@ addNode(new Finish());
 addNode(new GameOver());
 
 const st = JSON.parse(window.localStorage.getItem("stats")||"{}");
-console.log(st);
 stats.load(st);
 engine.goToScene(stats.currentNode);
 let showDebug = false;

--- a/src/scenes/example.ts
+++ b/src/scenes/example.ts
@@ -13,7 +13,7 @@ import { Lift } from "../actors/lift";
  */
 export class Example extends LevelLayout implements iSceneNode {
   thisScene = "example";
-  nextScene = "beforeLevel1";
+  nextScene = "finish";
   levelSize = new ex.Vector(22, 22);
 
   layoutLevel(engine: ex.Engine) {

--- a/src/scenes/level3.ts
+++ b/src/scenes/level3.ts
@@ -9,7 +9,7 @@ import { Lift } from "../actors/lift";
 
 export class Level3 extends LevelLayout implements iSceneNode {
   thisScene = "level3";
-  nextScene = "finish";
+  nextScene = "example";
 
   // Dit is de grootte van je level in (Breedte, Hoogte). Aanpassen mag!
   levelSize = new ex.Vector(22, 22);

--- a/src/scenes/playerSelect.ts
+++ b/src/scenes/playerSelect.ts
@@ -72,7 +72,7 @@ function sequence(scene: ex.Scene, actors: ex.Actor[]): void {
 
 export class PlayerSelect extends ex.Scene implements iSceneNode {
   thisScene: string = "playerSelect";
-  nextScene: string = "example";
+  nextScene: string = "level1";
 
   onInitialize(engine: ex.Engine) {
     engine.add(


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/WimYedema/alan-and-ada/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

<!--------------------------------------------------------------------------------------------->

Closes #32, #31 

## Changes:

- Example level is now at the end
- Stats are saved at the start of each level and restored at the beginning of the game
  Note that this means that it is harder to start from the beginning. A debug key <esc>R is added
