### PR TITLE
39 game hangs on using potion repeatedly

### DIFF
--- a/src/actors/potion.ts
+++ b/src/actors/potion.ts
@@ -68,9 +68,10 @@ export class Potion extends Artifact {
         this.potionColor == "purple" ? ex.Color.Magenta : ex.Color.Yellow,
       endColor: ex.Color.Transparent,
     });
-    this.scene.add(emitter);
-    this.killAfter(1.5, 10, () => {
+    if (this.killAfter(1.5, 10, () => {
       this.scene.remove(emitter);
-    });
+    })) {
+      this.scene.add(emitter);
+    };
   }
 }

--- a/src/actors/potion.ts
+++ b/src/actors/potion.ts
@@ -68,10 +68,12 @@ export class Potion extends Artifact {
         this.potionColor == "purple" ? ex.Color.Magenta : ex.Color.Yellow,
       endColor: ex.Color.Transparent,
     });
-    if (this.killAfter(1.5, 10, () => {
-      this.scene.remove(emitter);
-    })) {
+    if (
+      this.killAfter(1.5, 10, () => {
+        this.scene.remove(emitter);
+      })
+    ) {
       this.scene.add(emitter);
-    };
+    }
   }
 }

--- a/src/core/actor.ts
+++ b/src/core/actor.ts
@@ -1,6 +1,8 @@
 import * as ex from "excalibur";
 
 export class Actor extends ex.Actor {
+  dying: boolean = false;
+
   kill(respawn?: number): void {
     if (respawn !== undefined) {
       const scene = this.scene;
@@ -11,6 +13,9 @@ export class Actor extends ex.Actor {
     super.kill();
   }
   killAfter(seconds: number, respawn?: number, cb?: () => void): void {
+    if (this.dying) return;
+    //    console.log("kill after", seconds, this);
+    this.dying = true;
     this.scene.engine.clock.schedule(() => {
       if (cb !== undefined) cb();
       this.kill(respawn);

--- a/src/core/actor.ts
+++ b/src/core/actor.ts
@@ -12,14 +12,14 @@ export class Actor extends ex.Actor {
     }
     super.kill();
   }
-  killAfter(seconds: number, respawn?: number, cb?: () => void): void {
-    if (this.dying) return;
-    //    console.log("kill after", seconds, this);
+  killAfter(seconds: number, respawn?: number, cb?: () => void): boolean {
+    if (this.dying) return false;
     this.dying = true;
     this.scene.engine.clock.schedule(() => {
       if (cb !== undefined) cb();
       this.kill(respawn);
     }, seconds * 1000);
+    return true;
   }
 }
 


### PR DESCRIPTION
===:clipboard: PR Checklist :clipboard:===

- [x] :pushpin: issue exists in github for these changes
- [x] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/WimYedema/alan-and-ada/blob/master/STYLEGUIDE.md)
- [x] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [x] :page_facing_up: changelog entry added (or not needed)

==================

Closes #39 

## Changes:

- killAfter rejects multiple calls. It returns false on reject such that a caller can act on the success or rejection.

